### PR TITLE
CMakeLists: Fix building with MSVC-clang toolset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (MSVC)
         list(APPEND MCL_CXX_FLAGS /WX)
     endif()
 
-    if (CMAKE_VS_PLATFORM_TOOLSET MATCHES "LLVM-vs[0-9]+")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         list(APPEND MCL_CXX_FLAGS
              -Qunused-arguments
              -Wno-missing-braces)


### PR DESCRIPTION
Previous variant was not working for me, when I try to build dynarmic (as part of vita3k) with msvc-clang (cmake -T clangcl ...)
And also CMAKE_VS_PLATFORM_TOOLSET can be in any case, so here case insensitive comparison would be needed.