### PR TITLE
memory: Add memory literals

### DIFF
--- a/include/mcl/memory/literals.hpp
+++ b/include/mcl/memory/literals.hpp
@@ -1,0 +1,36 @@
+// This file is part of the mcl project.
+// Copyright (c) 2022 merryhime
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "mcl/stdint.hpp"
+
+namespace mcl::memory::literals {
+
+constexpr u64 operator""_KiB(unsigned long long int x)
+{
+    return 1024ULL * x;
+}
+
+constexpr u64 operator""_MiB(unsigned long long int x)
+{
+    return 1024_KiB * x;
+}
+
+constexpr u64 operator""_GiB(unsigned long long int x)
+{
+    return 1024_MiB * x;
+}
+
+constexpr u64 operator""_TiB(unsigned long long int x)
+{
+    return 1024_GiB * x;
+}
+
+constexpr u64 operator""_PiB(unsigned long long int x)
+{
+    return 1024_TiB * x;
+}
+
+}  // namespace mcl::memory::literals


### PR DESCRIPTION
Adds user-literals for specifying amounts of memory.

```cpp
	using namespace mcl::memory::literals;
	...
	const std::size_t BufferSize = 8_MiB;
	...
	std::byte LogBuffer[64_KiB];
	...
	Config.StackSize = 16_MiB;
	...
	class Foo {
	public:
		Foo() : memory_size_(64_MiB) {
	...
	std::size_t new_size = round_up(old_size, 64_KiB);
	...
	if( Size >= 1_GiB )
	...
	BufferThing(std::size_t InitialSize = 1_MiB);
	...
	const uint8_t BufferSizeWarning = 4_GiB;
	// warning: implicit conversion from 'std::uint64_t' (aka 'unsigned long') to 'const uint8_t' (aka 'const unsigned char') changes value from 4294967296 to 0 [-Wconstant-conversion]
	// const uint8_t BufferSizeWarning = 4_GiB;
	//               ~~~~~~~~~~~~~~~~~   ^~~~~
```